### PR TITLE
Fix macOS comment case

### DIFF
--- a/private_Library/private_Application Support/private_Cursor/User/settings.json
+++ b/private_Library/private_Application Support/private_Cursor/User/settings.json
@@ -1,6 +1,6 @@
 {
   // =========================================
-  // 💻 Terminal configuration for macOs
+  // 💻 Terminal configuration for macOS
   // =========================================
   // "terminal.integrated.profiles.osx": {
   //   "tmux": {


### PR DESCRIPTION
## Summary
- correct the case of `macOS` in VS Code settings

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684405a9a678832ab05de9e8bfabc767