### PR TITLE
Fix plugin source paths

### DIFF
--- a/dot_config/zsh/defer.zsh
+++ b/dot_config/zsh/defer.zsh
@@ -1,3 +1,3 @@
 zsh-defer source ~/.config/fzf/fzf.zsh
-zsh-defer source /path/to/zsh-autosuggestions/zsh-autosuggestions.zsh
-zsh-defer source /path/to/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+zsh-defer source ~/.local/share/sheldon/repos/github.com/zsh-users/zsh-autosuggestions/zsh-autosuggestions.zsh
+zsh-defer source ~/.local/share/sheldon/repos/github.com/zsh-users/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh


### PR DESCRIPTION
## Summary
- update autosuggestions path
- update syntax highlighting path

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684405aa6fbc832a8fd5f80ff48c4212