### PR TITLE
Fix history retrieval for linux shells

### DIFF
--- a/dot_config/zsh/functions.zsh
+++ b/dot_config/zsh/functions.zsh
@@ -8,7 +8,11 @@ ffileopen() {
 }
 
 fhistory(){
-  fc -e - -n "$(history | tail -r | sed 's/ *[0-9]* *//' | fzf)"
+  # Show command history in reverse order using builtin fc to support both macOS
+  # and GNU environments (tail -r isn't available everywhere)
+  local selected
+  selected=$(fc -lnr 1 | fzf)
+  [ -n "$selected" ] && fc -e - -n "$selected"
 }
 
 tmux-split-4() {


### PR DESCRIPTION
## Summary
- fix `fhistory` to avoid `tail -r`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684403ae0fc8832a9943a7052f001709